### PR TITLE
[OpenId][stable-3_4_0] Null Safety and JWT Handling for User Claims

### DIFF
--- a/classes/UserClaims.php
+++ b/classes/UserClaims.php
@@ -53,8 +53,19 @@ class UserClaims
     /**
      * Set the Claims values from an array.
      */
-    public function setValues(array $claimsParams): void
+    public function setValues(?array $claimsParams): void
     {
+
+        if (!is_array($claimsParams)) {
+            $this->id = null;
+            $this->email = null;
+            $this->username = null;
+            $this->givenName = null;
+            $this->familyName = null;
+            $this->emailVerified = null;
+            return;
+        }
+
         $this->id = $claimsParams['sub'] ?? null;
         $this->email = $claimsParams['email'] ?? null;
         $this->username = $claimsParams['preferred_username'] ?? null;

--- a/handler/OpenIDHandler.php
+++ b/handler/OpenIDHandler.php
@@ -431,6 +431,17 @@ class OpenIDHandler extends Handler
 			}
 
 			$userInfo = json_decode($response->getBody()->getContents(), true);
+			if($userInfo==null){
+				try {
+					$publicKey = $this->getOpenIDAuthenticationCert($providerSettings);
+					$claims = $this->getClaimsFromJwt([$response->getBody()], $publicKey);
+
+					return $claims;
+
+				} catch (Exception $e) {
+					error_log($e->getMessage());
+				}
+			} 
 
 			$claims = new UserClaims();
 			$claims->setValues($userInfo);


### PR DESCRIPTION
**tldr;**
Why
I got white screen on null UserClaims, because i was receiving it as JWT(Json Web Token)

Changes : 
Makes the setValues() method in UserClaims null-safe by handling null array inputs
Adds support for JWT-formatted UserInfo


**Problem**:
After successful OpenID Connect login, the application would display a white screen when fetching user information from the userinfo_endpoint. This occurred because:

1. The UserClaims object was unexpectedly receiving a JWT (JSON Web Token) format instead of the expected JSON
2. The setValues() method in UserClaims wasn't handling null inputs safely
3. The null claims resulted in a white screen due to unhandled null reference exceptions

**Changes Made:**

1. Null-Safe Handling in UserClaims
2. JWT Support for UserInfo

**Impact:**
No more white screen on login with openId when userclaims return null
Support for JWT UserInfo formats

**Tested with:**
OpenID providers that return JSON 
OpenID providers that return JWT-encoded 
Invalid/null responses to verify graceful degradation
