### PR TITLE
[OpenId][stable-3_4_0] Add multi custom configurations

### DIFF
--- a/OpenIDPlugin.php
+++ b/OpenIDPlugin.php
@@ -82,16 +82,18 @@ class OpenIDPlugin extends GenericPlugin
 		$request = Application::get()->getRequest();
 		$contextId = OpenIDPlugin::getContextData($request)->getId();
 		$settingsTMP = OpenIDPlugin::getOpenIDSettings($this, $contextId);
-	
-		foreach ($settingsTMP['provider'] as $key => $value) {
-			if(str_contains($key, $this::PROVIDER_CUSTOM)){
-				if (!self::$publicOpenidProviders->has($key)) {
-					self::$publicOpenidProviders->put(
-						$key , ["configUrl" => $value["configUrl"]]
-					);
+		if(isset($settingsTMP['provider'])){
+			foreach ($settingsTMP['provider'] as $key => $value) {
+				if(str_contains($key, $this::PROVIDER_CUSTOM)){
+					if (!self::$publicOpenidProviders->has($key)) {
+						self::$publicOpenidProviders->put(
+							$key , ["configUrl" => $value["configUrl"]]
+						);
+					}
 				}
 			}
 		}
+		
 	}
 
 	/**

--- a/OpenIDPlugin.php
+++ b/OpenIDPlugin.php
@@ -73,6 +73,25 @@ class OpenIDPlugin extends GenericPlugin
 			self::PROVIDER_MICROSOFT => ["configUrl" => "https://login.windows.net/{audience}/v2.0/.well-known/openid-configuration"],
 			self::PROVIDER_APPLE => ["configUrl" => "https://appleid.apple.com/.well-known/openid-configuration"],
 		]);
+
+		$this->addToPublicOpenidProviders();
+	}
+
+
+	function addToPublicOpenidProviders(){
+		$request = Application::get()->getRequest();
+		$contextId = OpenIDPlugin::getContextData($request)->getId();
+		$settingsTMP = OpenIDPlugin::getOpenIDSettings($this, $contextId);
+	
+		foreach ($settingsTMP['provider'] as $key => $value) {
+			if(str_contains($key, $this::PROVIDER_CUSTOM)){
+				if (!self::$publicOpenidProviders->has($key)) {
+					self::$publicOpenidProviders->put(
+						$key , ["configUrl" => $value["configUrl"]]
+					);
+				}
+			}
+		}
 	}
 
 	/**
@@ -481,5 +500,6 @@ class OpenIDPlugin extends GenericPlugin
 	{
 		return parent::getSetting(PKPApplication::CONTEXT_SITE, 'enabled');
 	}
+
 }
 

--- a/forms/OpenIDPluginSettingsForm.php
+++ b/forms/OpenIDPluginSettingsForm.php
@@ -112,6 +112,12 @@ class OpenIDPluginSettingsForm extends Form
 				'generateAPIKey',
 				'providerSync',
 				'disableFields',
+				'newProviderName',
+				'newProviderConfigUrl',
+				'newProviderBtnImg',
+				'newProviderBtnTxt',
+				'newProviderClientId',
+				'newProviderClientSecret'
 			]
 		);
 		parent::readInputData();
@@ -124,7 +130,7 @@ class OpenIDPluginSettingsForm extends Form
 	{
 		$redirectURL = $request->getDispatcher()
 			->url($request, PKPApplication::ROUTE_PAGE, OpenIDPlugin::getContextData($request)->getPath(), 'openid', 'doAuthentication');
-		
+
 		$templateMgr = TemplateManager::getManager($request);
 		$templateMgr->assign([
 			'pluginName' => $this->plugin->getName(),
@@ -145,6 +151,27 @@ class OpenIDPluginSettingsForm extends Form
 			$settingsTMP = OpenIDPlugin::getOpenIDSettings($this->plugin, $contextId);
 
 			$providerList = $this->getData('provider');
+
+			if ($this->getData('newProviderName')) {
+				if ($this->getData('newProviderName') == "" || $this->getData('newProviderConfigUrl') == "") {
+					return;
+				}
+
+				$newProviderName = "custom" . $this->getData('newProviderName');
+	
+				$newProvider = [];
+				$newProvider["active"] = "1";
+				$newProvider["configUrl"] = $this->getData('newProviderConfigUrl');
+				$newProvider["btnImg"] = $this->getData('newProviderBtnImg');
+				$newProvider["btnTxt"] = $this->getData('newProviderBtnTxt');
+				$newProvider["clientId"] = $this->getData('newProviderClientId');
+				$newProvider["clientSecret"] = $this->getData('newProviderClientSecret');
+
+				if (!isset($providerList[$newProviderName])) {
+					$providerList[$newProviderName] = $newProvider;
+				}
+			}
+		
 			$providerListResult = $this->_createProviderList($providerList, $settingsTMP['provider']);
 
 			$settings = [
@@ -157,6 +184,7 @@ class OpenIDPluginSettingsForm extends Form
 				'providerSync' => $this->getData('providerSync'),
 				'disableFields' => $this->getData('disableFields'),
 			];
+
 			$this->plugin->updateSetting($contextId, 'openIDSettings', json_encode($settings), 'string');
 
 			$notificationMgr = new NotificationManager();

--- a/handler/OpenIDLoginHandler.php
+++ b/handler/OpenIDLoginHandler.php
@@ -25,9 +25,14 @@ use Illuminate\Support\Facades\Http;
 use PKP\config\Config;
 use PKP\facades\Locale;
 use PKP\security\Validation;
+use Illuminate\Support\Collection;
 
 class OpenIDLoginHandler extends Handler
 {
+
+	public static Collection $customBtnImg;
+	public static Collection $customBtnTxt;
+
 	public function __construct(protected OpenIDPlugin $plugin)
 	{
 	}
@@ -300,6 +305,9 @@ class OpenIDLoginHandler extends Handler
 	{
 		$router = $request->getRouter();
 		$linkList = [];
+		
+		self::$customBtnImg = collect([]);
+		self::$customBtnTxt = collect([]);
 
 		foreach ($providerList as $provider => $settings) {
 			if (!empty($settings['authUrl']) && !empty($settings['clientId'])) {
@@ -314,17 +322,27 @@ class OpenIDLoginHandler extends Handler
 				$this->handleCustomProvider($provider, $settings, TemplateManager::getManager($request));
 			}
 		}
+		if(self::$customBtnTxt->isNotEmpty()){
+			TemplateManager::getManager($request)->assign([
+				'customBtnImg' => self::$customBtnImg,
+				'customBtnTxt' => self::$customBtnTxt
+			]);
+		}
+		
+
 		return $linkList;
 	}
 
+	 
+
+
 	private function handleCustomProvider(string $provider, array $settings, TemplateManager $templateMgr): void
 	{
-		if ($provider == OpenIDPlugin::PROVIDER_CUSTOM) {
+		if(str_contains($provider, OpenIDPlugin::PROVIDER_CUSTOM)){
 			$customBtnTxt = htmlspecialchars($settings['btnTxt'][Locale::getLocale()] ?? '', ENT_QUOTES, 'UTF-8');
-			$templateMgr->assign([
-				'customBtnImg' => $settings['btnImg'] ?? null,
-				'customBtnTxt' => $customBtnTxt
-			]);
+
+			self::$customBtnImg->put($provider,$settings['btnImg'] ?? null);
+			self::$customBtnTxt->put($provider,$customBtnTxt);
 		}
 	}
 

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -227,6 +227,9 @@ msgstr "<strong>Family name</strong> readonly"
 msgid "plugins.generic.openid.settings.features.disable.email"
 msgstr "<strong>Email</strong> readonly"
 
+msgid "plugins.generic.openid.settings.name"
+msgstr "Insert a name for your custom configuration"
+
 # error messages
 msgid "plugins.generic.openid.error.openid.connect.desc.key"
 msgstr "<strong>An error occurred while verifying your data.</strong><br />The service may not be available right now.<br />Please try again later and <a href='mailto:{$supportEmail}'>contact technical support</a> if the problem still exists."
@@ -253,6 +256,9 @@ msgstr "Sign in or register"
 msgid "plugins.generic.openid.select.legacy"
 msgstr "Sign in with your account at {$journalName}"
 
+msgid "plugins.generic.openid.select.provider.login"
+msgstr "Sign in with "
+
 msgid "plugins.generic.openid.select.provider.help"
 msgstr "Sign in or register with:"
 
@@ -273,6 +279,9 @@ msgstr "Sign in with Apple"
 
 msgid "plugins.generic.openid.select.provider.legacyRegister"
 msgstr "Register Account (without Oauth)"
+
+msgid "plugins.generic.openid.select.provider.add"
+msgstr "Add new custom provider"
 
 # disabled fields info
 msgid "plugins.generic.openid.disables.fields.info"

--- a/locale/es/locale.po
+++ b/locale/es/locale.po
@@ -331,6 +331,9 @@ msgstr "<strong>Apellidos</strong> solo de lectura"
 msgid "plugins.generic.openid.settings.features.disable.email"
 msgstr "<strong>Correo electrónico</strong> solo de lectura"
 
+msgid "plugins.generic.openid.settings.name"
+msgstr "Introduce un nombre para tu configuración personalizada"
+
 msgid "plugins.generic.openid.error.openid.disabled.without"
 msgstr ""
 "<strong>Esta cuenta se ha desactivado sin ningún motivo específico. Para "
@@ -345,6 +348,9 @@ msgstr ""
 
 msgid "plugins.generic.openid.select.legacy"
 msgstr "Iniciar sesión con su cuenta en {$journalName}"
+
+msgid "plugins.generic.openid.select.provider.login"
+msgstr "Iniciar sesión con "
 
 msgid "plugins.generic.openid.select.provider.help"
 msgstr "Iniciar sesión o registrarse con:"

--- a/templates/openidLogin.tpl
+++ b/templates/openidLogin.tpl
@@ -89,19 +89,19 @@
 		{if $linkList}
 			<li class="margin-top-30"><strong>{translate key='plugins.generic.openid.select.provider.help'}</strong></li>
 			{foreach from=$linkList key=name item=url}
-				{if $name == 'custom'}
+				{if $name|strstr:'custom' !== false}
 					<li><a id="openid-provider-{$name}" href="{$url}">
 							<div>
-								{if $customBtnImg}
-									<img src="{$customBtnImg}" alt="{$name}">
+								{if $customBtnImg[$name]}
+									<img src="{$customBtnImg[$name]}" alt="{$name}">
 								{else}
-									<img src="{$openIDImageURL}{$name}-sign-in.png" alt="{$name}">
+									<img src="{$openIDImageURL}custom-sign-in.png" alt="{$name}">
 								{/if}
 								<span>
-								{if isset($customBtnTxt)}
-									{$customBtnTxt}
+								{if $customBtnTxt[$name]}
+									{$customBtnTxt[$name]}
 								{else}
-									{{translate key="plugins.generic.openid.select.provider.$name"}}
+									{{translate key="plugins.generic.openid.select.provider.login"}}{{$name|capitalize:true}}
 								{/if}
 							</span>
 							</div>
@@ -111,7 +111,7 @@
 					<li class=""><a id="openid-provider-{$name}" href="{$url}">
 							<div>
 								<img src="{$openIDImageURL}{$name}-sign-in.png" alt="{$name}"/>
-								<span>{{translate key="plugins.generic.openid.select.provider.$name"}}</span>
+								<span>{{translate key="plugins.generic.openid.select.provider.login"}}{{$name|capitalize:true}}</span>
 							</div>
 						</a>
 					</li>

--- a/templates/openidLogin.tpl
+++ b/templates/openidLogin.tpl
@@ -89,7 +89,7 @@
 		{if $linkList}
 			<li class="margin-top-30"><strong>{translate key='plugins.generic.openid.select.provider.help'}</strong></li>
 			{foreach from=$linkList key=name item=url}
-				{if $name|strstr:'custom' !== false}
+				{if $name|strstr:'custom'}
 					<li><a id="openid-provider-{$name}" href="{$url}">
 							<div>
 								{if $customBtnImg[$name]}
@@ -101,7 +101,7 @@
 								{if $customBtnTxt[$name]}
 									{$customBtnTxt[$name]}
 								{else}
-									{{translate key="plugins.generic.openid.select.provider.login"}}{{$name|capitalize:true}}
+									{{translate key="plugins.generic.openid.select.provider.login"}}{{$name|replace:'custom':''|capitalize:true|trim} }
 								{/if}
 							</span>
 							</div>

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -66,7 +66,6 @@
 		font-weight: 600 !important;
 	}
 </style>
-<button class="pkp_button" id="addButton">{translate key="plugins.generic.openid.select.provider.add"}</button>
 <form
 	class="pkp_form"
 	id="openIDSettings"
@@ -99,7 +98,7 @@
 								{$redirectUrl|escape}{$providerSuffix}
 							</strong>
 						</p>
-						{if $name|strstr:'custom' !== false}
+						{if $name|strstr:'custom'}
 							{fbvElement type="text" id="provider[{$name}][configUrl]" value=$provider[{$name}]['configUrl']|default:$settings['configUrl'] maxlength="250" label="plugins.generic.openid.settings.configUrl.desc"}
 							<div style="clear: both;">&nbsp;</div>
 							<div>
@@ -126,6 +125,8 @@
 			</div>
 		{/foreach}
 	{/fbvFormArea}
+	<div class="pkp_button" id="addButton">{translate key="plugins.generic.openid.select.provider.add"}</div>
+	<div style="clear: both;">&nbsp;</div>
 	{fbvFormArea title="plugins.generic.openid.settings.features.head" id="open-id-features"}
 		<p>{translate key="plugins.generic.openid.settings.features.desc"}</p>
 		{fbvFormSection list=true}
@@ -163,14 +164,27 @@
 	{/fbvFormArea}
 	{fbvFormButtons}
 
-	<dialog 
+	<dialog
 	class="pkp_modal_panel"
 	id="addCustomDialog">
-		<section>
+		
+		<div style="position: absolute;right: 0; margin-right: 13px;" id="closeButton" class="pkp_button"><span :aria-hidden="true">×</span><span class="pkp_screen_reader">Close Panel</span></div>
+		
+		<legend>{translate key="plugins.generic.openid.select.provider.add"}</legend>
+		
+		<section >
 		<p>
-			<label class="label">{translate key="plugins.generic.openid.select.provider.add"}</label>
 			<div>
-			{fbvElement type="text" id="newProviderName" value="" maxlength="250" label="plugins.generic.openid.settings.name"}
+			{fbvElement type="text" id="newProviderName" value="" maxlength="250" label="plugins.generic.openid.settings.name" onkeypress="
+				this.value = this.value.toLowerCase();
+				var regex = new RegExp('^[a-zA-Z0-9]+$');
+				var str = String.fromCharCode(!event.charCode ? event.which : event.charCode);
+				if (!regex.test(str)) {
+					event.preventDefault();
+					return false;
+				}
+				return true;
+			"}
 			<div style="clear: both;">&nbsp;</div>
 			{fbvElement type="text" id="newProviderConfigUrl" value="" maxlength="250" label="plugins.generic.openid.settings.configUrl.desc"}
 			<div style="clear: both;">&nbsp;</div>
@@ -187,16 +201,22 @@
 		</p>
 		</section>
 
-		{fbvFormButtons}
+		{fbvFormButtons hideCancel=true}
 	</dialog>
 </form>
 <script>
 	(function () {
 		var addButton = document.getElementById("addButton");
+		var closeButton = document.getElementById("closeButton");
 		var addCustomDialog = document.getElementById("addCustomDialog");
 
 		addButton.addEventListener("click", function () {
 			addCustomDialog.showModal();
+		});
+
+		closeButton.addEventListener("click", function () {
+			addCustomDialog.close();
+			document.querySelector(`input[name="newProviderName"]`).value = '';
 		});
 	})();
 </script>

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -66,6 +66,7 @@
 		font-weight: 600 !important;
 	}
 </style>
+<button class="pkp_button" id="addButton">{translate key="plugins.generic.openid.select.provider.add"}</button>
 <form
 	class="pkp_form"
 	id="openIDSettings"
@@ -75,21 +76,31 @@
 	{csrf}
 	{fbvFormArea title="plugins.generic.openid.settings.openid.head" id="open-id-provider"}
 		<p>{translate key="plugins.generic.openid.settings.openid.desc"}</p>
-		{foreach from=$initProvider item=settings key=name}
+			{foreach from=$initProvider item=settings key=name}
 			<div class="showContent">
 				{fbvFormSection list=true style="padding: 0;" class="provider_list"}
-					{fbvElement type="checkbox" id="provider[{$name}][active]" checked=$provider[{$name}]['active']  value=1 label="plugins.generic.openid.settings.{$name}.enable" class="strong"}
+
+					{if "plugins.generic.openid.settings.{$name}.enable"|translate != "##plugins.generic.openid.settings.{$name}.enable##"}
+						{fbvElement type="checkbox" id="provider[{$name}][active]" checked=$provider[{$name}]['active']  value=1 label="plugins.generic.openid.settings.{$name}.enable" class="strong"}
+					{else}
+						{fbvElement type="checkbox" id="provider[{$name}][active]" checked=$provider[{$name}]['active']  value=1 label={$name|replace:'custom':''|capitalize:true|trim} class="strong"}
+					{/if}
 					<div class="hiddenContent">
 						{assign var='providerSuffix' value="?provider="|cat:$name}
 						<p>
-							{translate key="plugins.generic.openid.settings.{$name}.desc"}
+							{if "plugins.generic.openid.settings.{$name}.desc"|translate != "##plugins.generic.openid.settings.{$name}.desc##"}
+								{translate key="plugins.generic.openid.settings.{$name}.desc"}
+							{else}
+								{translate key="plugins.generic.openid.settings.custom.desc"}
+							{/if}
+						
 							&nbsp;
 							<strong>
 								{$redirectUrl|escape}{$providerSuffix}
 							</strong>
 						</p>
-						{if $name eq 'custom'}
-							{fbvElement type="text" id="provider[{$name}][configUrl]" value=$provider[{$name}]['configUrl'] maxlength="250" label="plugins.generic.openid.settings.configUrl.desc"}
+						{if $name|strstr:'custom' !== false}
+							{fbvElement type="text" id="provider[{$name}][configUrl]" value=$provider[{$name}]['configUrl']|default:$settings['configUrl'] maxlength="250" label="plugins.generic.openid.settings.configUrl.desc"}
 							<div style="clear: both;">&nbsp;</div>
 							<div>
 								<div><strong>{translate key="plugins.generic.openid.settings.btn.settings"}</strong></div>
@@ -147,6 +158,45 @@
 		{fbvElement type="checkbox" id="generateAPIKey" checked=$generateAPIKey value=true label="plugins.generic.openid.settings.generateAPIKey.check"}
 			<label class="sub_label">{translate key="plugins.generic.openid.settings.generateAPIKey.desc"}</label>
 		{/fbvFormSection}
+		{fbvFormSection list=true}
+		{/fbvFormSection}
 	{/fbvFormArea}
 	{fbvFormButtons}
+
+	<dialog 
+	class="pkp_modal_panel"
+	id="addCustomDialog">
+		<section>
+		<p>
+			<label class="label">{translate key="plugins.generic.openid.select.provider.add"}</label>
+			<div>
+			{fbvElement type="text" id="newProviderName" value="" maxlength="250" label="plugins.generic.openid.settings.name"}
+			<div style="clear: both;">&nbsp;</div>
+			{fbvElement type="text" id="newProviderConfigUrl" value="" maxlength="250" label="plugins.generic.openid.settings.configUrl.desc"}
+			<div style="clear: both;">&nbsp;</div>
+			{fbvElement type="text" id="newProviderBtnImg" label="plugins.generic.openid.settings.btnImg.desc" inline=true size=$fbvStyles.size.MEDIUM}
+			{fbvElement type="text" id="newProviderBtnTxt" maxlength="40" label="plugins.generic.openid.settings.btnTxt.desc" inline=true size=$fbvStyles.size.MEDIUM multilingual=true}
+			</div>
+			<div style="clear: both;">&nbsp;</div>
+			<div>
+			<div><strong>{translate key="plugins.generic.openid.settings.provider.settings"}</strong></div>
+			{fbvElement type="text" id="newProviderClientId" maxlength="250" label="plugins.generic.openid.settings.clientId.desc" inline=true size=$fbvStyles.size.MEDIUM}
+			{fbvElement type="text" id="newProviderClientSecret" maxlength="250" label="plugins.generic.openid.settings.clientSecret.desc" inline=true size=$fbvStyles.size.MEDIUM}
+			</div>	
+		
+		</p>
+		</section>
+
+		{fbvFormButtons}
+	</dialog>
 </form>
+<script>
+	(function () {
+		var addButton = document.getElementById("addButton");
+		var addCustomDialog = document.getElementById("addCustomDialog");
+
+		addButton.addEventListener("click", function () {
+			addCustomDialog.showModal();
+		});
+	})();
+</script>


### PR DESCRIPTION
This PR introduces a new way to register multiple custom providers at once with JSON or manually with plugin settings, making it easier for users to add and manage custom providers in their instances of OJS.

**Changes**

 - Added new JSON file that can stores infinite providers without need to hard-code it in PHP code.
 - Implemented new way for login strings in a more easy to add new providers  

**Motivation**

Currently, adding multiple custom providers requires manually adding to PHP code. This new approach:

 - Reduces complexity to add more than 1 custom provider.
 - Simplifies adding multiple providers and exporting to other configurations.

JSON example:

```json
[{"name":"customtest","configUrl":"https:\/\/orcid.org\/.well-known\/openid-configuration"},{"name":"customrediris","configUrl":"https:\/\/oidc.sir2.rediris.es\/es.rediris.sir2.test\/module.php\/oidc\/openid-configuration.php"}]
```
_This JSON is created automatically if didn't not exist with plugin settings._
