### PR TITLE
Adapt user forms to OJS 3.4

### DIFF
--- a/templates/user/apiProfileForm.tpl
+++ b/templates/user/apiProfileForm.tpl
@@ -2,9 +2,9 @@
  * templates/user/apiProfileForm.tpl
  *
  * Copyright (c) 2020 Leibniz Institute for Psychology Information (https://leibniz-psychology.org/)
- * Copyright (c) 2024 Simon Fraser University
- * Copyright (c) 2024 John Willinsky
- * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * Public user profile form.
  *}
@@ -30,22 +30,35 @@
 	{/if}
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="apiProfileNotification"}
 
-	{fbvFormSection list=true}
-		{fbvElement id=apiKeyEnabled type="checkbox" label="user.apiKeyEnabled" checked=$apiKeyEnabled value=1 readonly=$openidApiFields disabled=$openidApiFields}
-		{fbvElement id=generateApiKey type="checkbox" label="user.apiKey.generate" value=1 readonly=$openidApiFields disabled=$openidApiFields}
-	{/fbvFormSection}
-	<p>{translate key="user.apiKey.generateWarning"}</p>
-
-	{fbvFormSection}
+	{fbvFormSection title="user.apiKey"}
 		{if !$apiKey}{assign var=apiKey value="common.none"|translate}{/if}
-		{fbvElement id=apiKey type="text" label="user.apiKey" readonly="true" value=$apiKey size=$fbvStyles.size.MEDIUM}
+		{fbvElement id=apiKey type="text" readonly="true" inline=true value=$apiKey size=$fbvStyles.size.MEDIUM}
+		{if !$apiSecretMissing}
+			{fbvElement id=apiKeyAction type="hidden" readonly="true" value=$apiKeyAction}
+			<button
+				type="submit"
+				{if $apiKeyAction === \PKP\user\form\APIProfileForm::API_KEY_DELETE}
+					onClick="return confirm({translate|json_encode|escape key='user.apiKey.remove.confirmation.message'})"
+					class="pkpButton pkpButton--isWarnable"
+				{else}
+					class="pkp_button pkp_button_primary"
+				{/if}
+			>
+				{translate key=$apiKeyActionTextKey}
+			</button>
+		{/if}
+		<p>
+			{translate key=($apiKeyAction === \PKP\user\form\APIProfileForm::API_KEY_NEW) ? "user.apiKey.generateWarning" : "user.apiKey.removeWarning"}
+		</p>
 	{/fbvFormSection}
 
 	<p>
-		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{capture assign="privacyUrl"}
+			{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}
+		{/capture}
 		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
 	</p>
-
+    
 	{if !$openidApiFields}
 		{fbvFormButtons hideCancel=true submitText="common.save"}
 	{/if}

--- a/templates/user/changePassword.tpl
+++ b/templates/user/changePassword.tpl
@@ -2,12 +2,13 @@
  * templates/user/changePassword.tpl
  *
  * Copyright (c) 2020 Leibniz Institute for Psychology Information (https://leibniz-psychology.org/)
- * Copyright (c) 2024 Simon Fraser University
- * Copyright (c) 2024 John Willinsky
- * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * Form to change a user's password.
  *}
+
 <script>
 	$(function() {ldelim}
 		// Attach the form handler.
@@ -18,7 +19,9 @@
 <form class="pkp_form" id="changePasswordForm" method="post" action="{url op="savePassword"}">
 	{* Help Link *}
 	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
+
 	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="changePasswordFormNotification"}
 	{if isset($openIdDisableFields) && !empty($openIdDisableFields)}
 		{assign var="openidPWFields" value=true }
@@ -27,18 +30,19 @@
 		</p>
 	{/if}
 	<p><span class="instruct">{translate key="user.profile.changePasswordInstructions"}</span></p>
+
 	{fbvFormArea id="changePasswordFormArea"}
 		{fbvFormSection label="user.profile.oldPassword"}
-			{fbvElement type="text" password="true" id="oldPassword" value=$oldPassword maxLength="32" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
+			{fbvElement type="text" password="true" id="oldPassword" maxLength="32" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
 		{/fbvFormSection}
 		{fbvFormSection label="user.profile.newPassword"}
 			{capture assign="passwordLengthRestriction"}{translate key="user.register.form.passwordLengthRestriction" length=$minPasswordLength}{/capture}
-			{fbvElement type="text" password="true" id="password" value=$oldPassword label=$passwordLengthRestriction subLabelTranslate=false maxLength="32" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
-			{fbvElement type="text" password="true" id="password2" value=$oldPassword maxLength="32" label="user.profile.repeatNewPassword" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
+			{fbvElement type="text" password="true" id="password" label=$passwordLengthRestriction subLabelTranslate=false maxLength="32" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
+			{fbvElement type="text" password="true" id="password2" maxLength="32" label="user.profile.repeatNewPassword" size=$fbvStyles.size.MEDIUM readonly=$openidPWFields disabled=$openidPWFields}
 		{/fbvFormSection}
 
 		<p>
-			{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+			{capture assign="privacyUrl"}{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}{/capture}
 			{translate key="user.privacyLink" privacyUrl=$privacyUrl}
 		</p>
 

--- a/templates/user/contactForm.tpl
+++ b/templates/user/contactForm.tpl
@@ -2,12 +2,13 @@
  * templates/user/contactForm.tpl
  *
  * Copyright (c) 2020 Leibniz Institute for Psychology Information (https://leibniz-psychology.org/)
- * Copyright (c) 2024 Simon Fraser University
- * Copyright (c) 2024 John Willinsky
- * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * User profile form.
  *}
+
 <script>
 	$(function() {ldelim}
 		// Attach the form handler.
@@ -44,18 +45,18 @@
 	{if count($availableLocales) > 1}
 		{fbvFormSection title="user.workingLanguages" list=true}
 			{foreach from=$availableLocales key=localeKey item=localeName}
-				{if $userLocales && in_array($localeKey, $userLocales)}
+				{if $locales && in_array($localeKey, $locales)}
 					{assign var="checked" value=true}
 				{else}
 					{assign var="checked" value=false}
 				{/if}
-				{fbvElement type="checkbox" name="userLocales[]" id="userLocales-$localeKey" value=$localeKey checked=$checked label=$localeName translate=false}
+				{fbvElement type="checkbox" name="locales[]" id="locales-$localeKey" value=$localeKey checked=$checked label=$localeName|escape translate=false}
 			{/foreach}
 		{/fbvFormSection}
 	{/if}
 
 	<p>
-		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{capture assign="privacyUrl"}{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}{/capture}
 		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
 	</p>
 

--- a/templates/user/identityForm.tpl
+++ b/templates/user/identityForm.tpl
@@ -2,9 +2,9 @@
  * templates/user/identityForm.tpl
  *
  * Copyright (c) 2020 Leibniz Institute for Psychology Information (https://leibniz-psychology.org/)
- * Copyright (c) 2024 Simon Fraser University
- * Copyright (c) 2024 John Willinsky
- * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * User profile form.
  *}
@@ -16,22 +16,10 @@
 	{rdelim});
 </script>
 
-<style>
-	.cmp_notification {
-		display: block;
-		width: 100%;
-		padding: 20px;
-		margin-bottom: 40px;
-		background: #ddd;
-		border-left: 5px solid #007ab2;
-		font-size: 14px;
-		line-height: 20px;
-	}
-</style>
-
 <form class="pkp_form" id="identityForm" method="post" action="{url op="saveIdentity"}" enctype="multipart/form-data">
 	{* Help Link *}
 	{help file="user-profile" class="pkp_help_tab"}
+
 	{csrf}
 	{if ($openIdGivenNameDisabledField || $openIdFamilyNameDisabledField)}
 		{assign var="openidIdentityFields" value=true }
@@ -59,7 +47,7 @@
 	{/fbvFormSection}
 
 	<p>
-		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{capture assign="privacyUrl"}{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}{/capture}
 		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
 	</p>
 

--- a/templates/user/publicProfileForm.tpl
+++ b/templates/user/publicProfileForm.tpl
@@ -2,9 +2,9 @@
  * templates/user/publicProfileForm.tpl
  *
  * Copyright (c) 2020 Leibniz Institute for Psychology Information (https://leibniz-psychology.org/)
- * Copyright (c) 2024 Simon Fraser University
- * Copyright (c) 2024 John Willinsky
- * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * Public user profile form.
  *}
@@ -24,8 +24,11 @@
 					baseUrl: {$baseUrl|json_encode},
 					filters: {ldelim}
 						mime_types : [
-							{ldelim} title : "Image files", extensions : "jpg,jpeg,png,svg,gif" {rdelim}
+							{ldelim} title : "Image files", extensions : "jpg,jpeg,png,gif" {rdelim}
 						]
+					{rdelim},
+					multipart_params: {ldelim}
+						csrfToken: {csrf type="json"}
 					{rdelim},
 					resize: {ldelim}
 						width: {$profileImageMaxWidth|intval},
@@ -38,6 +41,11 @@
 	{rdelim});
 </script>
 
+{* Form for deleting the profile image (placed here to avoid nesting forms) *}
+<form type="post" action="{url op="deleteProfileImage"}" id="deleteProfileImageForm">
+	{csrf}
+</form>
+
 <form class="pkp_form" id="publicProfileForm" method="post" action="{url op="savePublicProfile"}" enctype="multipart/form-data">
 	{csrf}
 
@@ -48,7 +56,7 @@
 			{* Add a unique ID to prevent caching *}
 			<img src="{$baseUrl}/{$publicSiteFilesPath}/{$profileImage.uploadName}?{""|uniqid}" alt="{translate key="user.profile.form.profileImage"}" />
 			<div>
-				<a class="pkp_button pkp_button_offset" href="{url op="deleteProfileImage"}">{translate key="common.delete"}</a>
+				<button onclick="document.getElementById('deleteProfileImageForm').submit(); return false;" class="pkp_button pkp_button_offset">{translate key="common.delete"}</button>
 			</div>
 		{/if}
 	{/fbvFormSection}
@@ -67,19 +75,19 @@
 
 	{fbvFormSection}
 		{if !isset($openIdDisableFields) || !key_exists('lastProvider', $openIdDisableFields) || $openIdDisableFields['lastProvider'] ne 'orcid' || !isset($check_orcid) || !empty($check_orcid)}
-			{fbvElement type="text" label="user.orcid" name="orcid" id="orcid" value=$orcid maxlength="37"}
+			{fbvElement type="text" label="user.orcid" name="orcid" id="orcid" value=$orcid maxlength="46"}
 		{else}
 			<p class="cmp_notification">
 				{translate key="plugins.generic.openid.disables.fields.info.orcid"}
 			</p>
-			{fbvElement type="text" label="user.orcid" name="orcid" id="orcid" value=$orcid maxlength="37" readonly="true" }
+			{fbvElement type="text" label="user.orcid" name="orcid" id="orcid" value=$orcid maxlength="46" readonly="true" }
 		{/if}
 	{/fbvFormSection}
 
 	{call_hook name="User::PublicProfile::AdditionalItems"}
 
 	<p>
-		{capture assign="privacyUrl"}{url router=$smarty.const.ROUTE_PAGE page="about" op="privacy"}{/capture}
+		{capture assign="privacyUrl"}{url router=\PKP\core\PKPApplication::ROUTE_PAGE page="about" op="privacy"}{/capture}
 		{translate key="user.privacyLink" privacyUrl=$privacyUrl}
 	</p>
 


### PR DESCRIPTION
In the OJS 3.4 branch, still the old user templates were used from OJS 3.3. This led to malfunction/nonfunction of the user profile forms in OJS 3.4. This fix remedies that.